### PR TITLE
Update partitions.sh

### DIFF
--- a/partitions.sh
+++ b/partitions.sh
@@ -28,4 +28,12 @@ fi
 
 CORES=`cat /proc/cpuinfo|grep 'cpu cores'|sort|uniq|cut -d: -f 2`
 CPUS=`cat /proc/cpuinfo|grep 'physical id'|sort|uniq|wc -l`
-echo `expr $CORES "*" $CPUS "*" $NODES "/" 2`
+PARTTIONS=`expr $CORES "*" $CPUS "*" $NODES "/" 2`
+
+# Default partitions to 2 where calc yields 0 or 1 
+if [ -z $PARTITIONS ] || [ $PARTITIONS -eq 1 ]
+then
+    PARTITIONS=2
+fi
+
+echo $PARTTIONS


### PR DESCRIPTION
When this script is run against an Oracle Virtual Box (Configured by Vagrant) this script yields a value of 0 (CPU and CORE expressions both yield 1).
This is not acceptable as it causes the reliant process to fail. 0 or 1 are not a valid number when partitioning a table. 
Default to 2 where this occurs.
